### PR TITLE
Full support for split comp speeds

### DIFF
--- a/src/elm/DappInterface/OverviewHeader.elm
+++ b/src/elm/DappInterface/OverviewHeader.elm
@@ -244,11 +244,11 @@ netAPYView maybeConfig maybeEtherUsdPrice ({ userLanguage } as mainModel) =
                                                 cTokenMetadata.totalBorrows
                                                     |> Decimal.mul tokenValueUsd
 
-                                            compRate marketTotalUSDValue =
-                                                Utils.CompAPYHelper.compRate compUSDPrice cTokenMetadata.compSpeedPerDay marketTotalUSDValue
+                                            compRate marketTotalUSDValue compSpeedPerDayValue =
+                                                Utils.CompAPYHelper.compRate compUSDPrice compSpeedPerDayValue marketTotalUSDValue
                                                     |> Maybe.withDefault Decimal.zero
                                         in
-                                        ( compRate totalSupplyUsd, compRate totalBorrowUsd )
+                                        ( compRate totalSupplyUsd cTokenMetadata.compSupplySpeedPerDay, compRate totalBorrowUsd cTokenMetadata.compBorrowSpeedPerDay )
 
                                     _ ->
                                         ( Decimal.zero, Decimal.zero )

--- a/src/elm/DappInterface/PrimaryActionModal.elm
+++ b/src/elm/DappInterface/PrimaryActionModal.elm
@@ -554,8 +554,14 @@ assetAndCompRateForm userLanguage config maybeEtherUsdPrice ({ chosenAsset, prim
                                 else
                                     cTokenMetadata.totalBorrows
                                         |> Decimal.mul tokenValueUsd
+
+                            compSpeedPerDayForAction =
+                                if primaryActionType == MintAction || primaryActionType == RedeemAction then
+                                    cTokenMetadata.compSupplySpeedPerDay
+                                else
+                                    cTokenMetadata.compBorrowSpeedPerDay
                         in
-                        ( marketTotalUsdForAction, cTokenMetadata.compSpeedPerDay )
+                        ( marketTotalUsdForAction, compSpeedPerDayForAction )
                     )
                 |> Maybe.withDefault ( Decimal.zero, Decimal.zero )
 

--- a/src/elm/Eth/Compound.elm
+++ b/src/elm/Eth/Compound.elm
@@ -82,8 +82,10 @@ type alias CTokenMetadata =
     , totalReserves : Decimal
     , totalSupply : Decimal
     , totalSupplyUnderlying : Decimal
-    , compSpeedPerBlock : Decimal
-    , compSpeedPerDay : Decimal
+    , compSupplySpeedPerBlock : Decimal
+    , compSupplySpeedPerDay : Decimal
+    , compBorrowSpeedPerBlock: Decimal
+    , compBorrowSpeedPerDay : Decimal
     , borrowCap : Decimal
     }
 
@@ -121,8 +123,10 @@ type alias CTokenMetadataUpdate =
     , totalReserves : Decimal
     , totalSupply : Decimal
     , totalSupplyUnderlying : Decimal
-    , compSpeedPerBlock : Decimal
-    , compSpeedPerDay : Decimal
+    , compSupplySpeedPerBlock : Decimal
+    , compSupplySpeedPerDay : Decimal
+    , compBorrowSpeedPerBlock: Decimal
+    , compBorrowSpeedPerDay : Decimal
     , borrowCap : Decimal
     }
 
@@ -256,7 +260,7 @@ compoundUpdate config tokenState oracleState msg ( state, bnState ) =
                 updatedMetaData =
                     cTokenMetadataList
                         |> List.foldl
-                            (\{ cTokenAddress, exchangeRate, supplyRatePerDay, borrowRatePerDay, collateralFactor, reserveFactor, totalBorrows, totalUnderlyingCash, totalReserves, totalSupply, totalSupplyUnderlying, compSpeedPerBlock, compSpeedPerDay, borrowCap } acc ->
+                            (\{ cTokenAddress, exchangeRate, supplyRatePerDay, borrowRatePerDay, collateralFactor, reserveFactor, totalBorrows, totalUnderlyingCash, totalReserves, totalSupply, totalSupplyUnderlying, compSupplySpeedPerBlock, compSupplySpeedPerDay, compBorrowSpeedPerBlock, compBorrowSpeedPerDay, borrowCap } acc ->
                                 Dict.insert
                                     (getContractAddressString cTokenAddress)
                                     { exchangeRate = exchangeRate
@@ -269,8 +273,10 @@ compoundUpdate config tokenState oracleState msg ( state, bnState ) =
                                     , totalReserves = totalReserves
                                     , totalSupply = totalSupply
                                     , totalSupplyUnderlying = totalSupplyUnderlying
-                                    , compSpeedPerBlock = compSpeedPerBlock
-                                    , compSpeedPerDay = compSpeedPerDay
+                                    , compSupplySpeedPerBlock = compSupplySpeedPerBlock
+                                    , compSupplySpeedPerDay = compSupplySpeedPerDay
+                                    , compBorrowSpeedPerBlock = compBorrowSpeedPerBlock
+                                    , compBorrowSpeedPerDay = compBorrowSpeedPerDay
                                     , borrowCap = borrowCap
                                     }
                                     acc
@@ -664,16 +670,23 @@ giveCTokenMetadata wrapper =
                 (field "totalBorrows" decimal)
                 (field "totalUnderlyingCash" decimal)
 
+        stage2 =
+            (Json.Decode.map6
+                (<|)
+                stage1
+                (field "totalReserves" decimal)
+                (field "totalSupply" decimal)
+                (field "totalSupplyUnderlying" decimal)
+                (field "compSupplySpeedPerBlock" decimal)
+                (field "compSupplySpeedPerDay" decimal)
+            )
         decoder =
             Json.Decode.list
-                (Json.Decode.map7
+                (Json.Decode.map4
                     (<|)
-                    stage1
-                    (field "totalReserves" decimal)
-                    (field "totalSupply" decimal)
-                    (field "totalSupplyUnderlying" decimal)
-                    (field "compSpeedPerBlock" decimal)
-                    (field "compSpeedPerDay" decimal)
+                    stage2
+                    (field "compBorrowSpeedPerBlock" decimal)
+                    (field "compBorrowSpeedPerDay" decimal)
                     (field "borrowCap" decimal)
                 )
     in

--- a/src/js/ports.js
+++ b/src/js/ports.js
@@ -276,8 +276,10 @@ function subscribeToCTokenPorts(app, eth) {
               totalSupply: toScaledDecimal(parseWeiStr(totalSupplyResult), cTokenDecimals),
               totalSupplyUnderlying: toScaledDecimal(totalSupplyScaled * oneCTokenInUnderlying, 0),
               totalUnderlyingCash: totalCash,
-              compSpeedPerBlock: toScaledDecimal(parseWeiStr(compSupplySpeedResult), EXP_DECIMALS),
-              compSpeedPerDay: toScaledDecimal(parseWeiStr(compSupplySpeedResult).mul(BLOCKS_PER_DAY), EXP_DECIMALS),
+              compSupplySpeedPerBlock: toScaledDecimal(parseWeiStr(compSupplySpeedResult), EXP_DECIMALS),
+              compSupplySpeedPerDay: toScaledDecimal(parseWeiStr(compSupplySpeedResult).mul(BLOCKS_PER_DAY), EXP_DECIMALS),
+              compBorrowSpeedPerBlock: toScaledDecimal(parseWeiStr(compBorrowSpeedResult), EXP_DECIMALS),
+              compBorrowSpeedPerDay: toScaledDecimal(parseWeiStr(compBorrowSpeedResult).mul(BLOCKS_PER_DAY), EXP_DECIMALS),
               borrowCap: toScaledDecimal(parseWeiStr(borrowCapResult), underlyingDecimals)
             };
           }


### PR DESCRIPTION
Commit 558794b131a41e4cefc02de34077b43b4c5409de was a temporary patch which assumed supply and borrow COMP speeds were the same (currently true). This removes that assumption