### PR TITLE
Update tally integration

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.22.17.cjs

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "chalk": "^4.0.0",
     "clean-webpack-plugin": "^3.0.0",
     "cli-table": "0.3.1",
-    "compound-components": "https://github.com/compound-finance/compound-components.git#75fa6c7a1515722ee788a585836ccc7407dd7598",
+    "compound-components": "https://github.com/compound-finance/compound-components.git#e07cd9f7f4a55c81c630481b8dba761faa3c4c8a",
     "compound-config": "https://github.com/compound-finance/compound-config.git#b6cbc8bbfb8df201dc9e3e5860ae68dea84c4c9b",
     "connect-history-api-fallback": "^1.5.0",
     "core-js": "3",

--- a/src/strings/strings.en.json
+++ b/src/strings/strings.en.json
@@ -124,7 +124,10 @@
   "tally": "Tally",
   "unlock_tally_wallet": "Unlock Tally Wallet",
   "click_tally_extension": "Tip: If you would prefer to use Tally instead, please download Tally or ensure it is set to default",
+  "click_mm_extension": "Tip: If you would prefer to use Metamask instead, please ensure Tally is not set as default",
   "decline_unlock_tally_wallet": "We have detected that you have MetaMask installed.",
+  "decline_unlock_mm_wallet": "We have detected that you have Tally installed.",
+
 
   
   "queued_transactions": "Queued Transactions",

--- a/src/strings/strings.es.json
+++ b/src/strings/strings.es.json
@@ -124,7 +124,10 @@
     "tally": "Cuenta",
     "unlock_tally_wallet": "Desbloquear billetera Tally",
     "click_tally_extension": "Sugerencia: si prefiere usar Tally en su lugar, descargue Tally o asegúrese de que esté configurado de forma predeterminada",
+    "click_mm_extension": "Consejo: si prefiere usar Metamask en su lugar, asegúrese de que Tally no esté configurado como predeterminado",
     "decline_unlock_tally_wallet": "Hemos detectado que tienes MetaMask instalado.",
+    "decline_unlock_mm_wallet": "Hemos detectado que tienes Tally instalado.",
+
 
   
     "queued_transactions": "Transacciones en cola",

--- a/src/strings/strings.fr.json
+++ b/src/strings/strings.fr.json
@@ -124,7 +124,10 @@
     "tally": "Pointage",
     "unlock_tally_wallet": "Déverrouiller le portefeuille Tally",
     "click_tally_extension": "Conseil : Si vous préférez utiliser Tally à la place, veuillez télécharger Tally ou assurez-vous qu'il est défini par défaut",
+    "click_mm_extension": "Conseil : Si vous préférez utiliser Metamask à la place, assurez-vous que Tally n'est pas défini par défaut.",
     "decline_unlock_tally_wallet": "Nous avons détecté que vous avez installé MetaMask.",
+    "decline_unlock_mm_wallet": "Nous avons détecté que vous avez installé Tally.",
+
 
   
     "queued_transactions": "Transactions en file d'attente",

--- a/src/strings/strings.ko.json
+++ b/src/strings/strings.ko.json
@@ -124,7 +124,10 @@
     "tally": "계정",
     "unlock_tally_wallet": "탈리 지갑 잠금 해제",
     "click_tally_extension": "팁: Tally를 대신 사용하려면 Tally를 다운로드하거나 기본값으로 설정되어 있는지 확인하십시오.",
+    "click_mm_extension": "팁: 메타마스크를 대신 사용하려면 Tally가 기본값으로 설정되어 있지 않은지 확인하십시오.",
     "decline_unlock_tally_wallet": "MetaMask가 설치되어 있음을 감지했습니다.",
+    "decline_unlock_mm_wallet": "Tally가 설치되어 있음을 감지했습니다.",
+
 
   
     "queued_transactions": "대기 중인 트랜잭션",

--- a/src/strings/strings.zh.json
+++ b/src/strings/strings.zh.json
@@ -124,7 +124,10 @@
     "tally": "相符",
     "unlock_tally_wallet": "解锁 Tally 钱包",
     "click_tally_extension": "提示：如果您更喜欢使用 Tally，请下载 Tally 或确保将其设置为默认值",
+    "click_mm_extension": "提示：如果您更愿意使用 Metamask，请确保 Tally 未设置为默认值",
     "decline_unlock_tally_wallet": "我们检测到您安装了 MetaMask。",
+    "decline_unlock_mm_wallet": "我们检测到您安装了 Tally。",
+
 
   
     "queued_transactions": "排队的交易",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3366,9 +3366,9 @@ component-emitter@^1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
-"compound-components@https://github.com/compound-finance/compound-components.git#75fa6c7a1515722ee788a585836ccc7407dd7598":
+"compound-components@https://github.com/compound-finance/compound-components.git#e07cd9f7f4a55c81c630481b8dba761faa3c4c8a":
   version "1.0.0"
-  resolved "https://github.com/compound-finance/compound-components.git#75fa6c7a1515722ee788a585836ccc7407dd7598"
+  resolved "https://github.com/compound-finance/compound-components.git#e07cd9f7f4a55c81c630481b8dba761faa3c4c8a"
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/preset-env" "^7.0.0"


### PR DESCRIPTION
Integrates the fixes from compound components pr here: https://github.com/compound-finance/compound-components/pull/67

Also adds the files to allow machines with yarn2 to still run `yarn install` and use version1 for projects that are still on version 1.