### PR TITLE
Fix ipfs-deploy script

### DIFF
--- a/scripts/ipfs.js
+++ b/scripts/ipfs.js
@@ -24,7 +24,8 @@ function buildIpfsClient() {
     agent: new Agent({
       keepAlive: false,
       maxSockets: Infinity
-    })
+    }),
+    timeout: '10m'
   });
 }
 
@@ -33,7 +34,7 @@ function buildIpfsClient() {
   function progress(size, path) {
     console.log(`Sent ${Math.round(size / 1000)}KB for ${path}`);
   }
-  let app = await ipfs.add(ipfsClient.globSource('build', { recursive: true, progress }), { timeout: 600000 });
+  let app = await ipfs.add(ipfsClient.globSource('build', { recursive: true, progress }));
   if (app === null) {
     throw new Error("Missing core application cid");
   }


### PR DESCRIPTION
Latest changes were failing to deploy to ipfs as it looks like the api move the timeout option from the `ipfs.add()` function into the `ipfs.create()` call instead.