### PR TITLE
Fix testnets after Prop 117 workaround

### DIFF
--- a/src/js/ports.js
+++ b/src/js/ports.js
@@ -382,13 +382,16 @@ function subscribeToComptrollerPorts(app, eth) {
       .catch(reportError(app));
   });
 
-  // port askOraclePricesAllPort : { blockNumber : Int, priceOracleAddress : String, cTokenAddress : String, underlyingAssetAddress : String } -> Cmd msg
-  app.ports.askOraclePricesAllPort.subscribe(async({ blockNumber, cTokens: cTokenEntries, compoundLens }) => {
+  // port askOraclePricesAllPort : { blockNumber : Int, priceOracleAddress : String, cTokenAddress : String, underlyingAssetAddress : String, callEthPrice : bool } -> Cmd msg
+  app.ports.askOraclePricesAllPort.subscribe(async({ blockNumber, cTokens: cTokenEntries, compoundLens, callEthPrice }) => {
     const CompoundLens = getContractJsonByName(eth, 'CompoundLens');
     let cTokens = supportFromEntries(cTokenEntries);
 
     const PriceOracleProxy = getContractJsonByName(eth, 'PriceOracleProxy');
-    let ethPriceResult = await wrapCall(app, eth, [[PriceOracleProxy, "0x65c816077C29b557BEE980ae3cC2dCE80204A0C5", 'getUnderlyingPrice', ['0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5']]], blockNumber)
+    let ethPriceResult;
+    if(callEthPrice) {
+      ethPriceResult = await wrapCall(app, eth, [[PriceOracleProxy, "0x65c816077C29b557BEE980ae3cC2dCE80204A0C5", 'getUnderlyingPrice', ['0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5']]], blockNumber)
+    }
     //TODO: Use instead the same call as new Lens is making for consistency.
 
     wrapCall(app, eth, [[CompoundLens, compoundLens, 'cTokenUnderlyingPriceAll', [Object.keys(cTokens)]]], blockNumber)
@@ -402,12 +405,14 @@ function subscribeToComptrollerPorts(app, eth) {
           };
         });
 
-        let ethPriceHardcoded = {
-          underlyingAssetAddress: "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
-          value: toScaledDecimal(ethPriceResult, EXP_DECIMALS)
-        };
+        if(callEthPrice) {
+          let ethPriceHardcoded = {
+            underlyingAssetAddress: "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+            value: toScaledDecimal(ethPriceResult, EXP_DECIMALS)
+          };
 
-        allPricesList.push(ethPriceHardcoded);
+          allPricesList.push(ethPriceHardcoded);
+        }
 
         app.ports.giveOraclePricesAllPort.send(allPricesList);
       })


### PR DESCRIPTION
Our fix for Prop 117 was to make a call out to the previous price oracle for Eth but this happened regardless of what network was actually connected by the user.

This change only enables the prop 117 workaround if we are on mainnet and should bring back the testnets.