### PR TITLE
Update markets as deprecated, and hide markets with mintGuardianPaused

### DIFF
--- a/src/elm/Balances.elm
+++ b/src/elm/Balances.elm
@@ -3,6 +3,7 @@ module Balances exposing
     , getCollateralValueInUsd
     , getHasAnyAssetEnabledForBorrowing
     , getInterestRate
+    , getMintGuardianPaused
     , getUnderlyingBalances
     , getUnderlyingInterestBalances
     , getUnderlyingTotalsInUsd
@@ -12,14 +13,13 @@ module Balances exposing
     )
 
 import CompoundComponents.Eth.Ethereum as Ethereum exposing (Account(..), AssetAddress(..), ContractAddress(..), CustomerAddress(..), getContractAddressString)
-import CompoundComponents.Eth.Ledger exposing (LedgerAccount, ledgerAccountToInt)
 import CompoundComponents.Functions as Functions
 import Decimal exposing (Decimal)
-import Dict exposing (Dict)
-import Eth.Compound exposing (CTokenBalances, CTokenBalancesDict, CTokenInterestBalances, CTokenMetadata, CTokenMetadataDict, CompoundState)
+import Dict 
+import Eth.Compound exposing (CTokenBalances, CTokenInterestBalances, CTokenMetadataDict, CompoundState)
 import Eth.Config exposing (Config)
 import Eth.Oracle exposing (OracleState)
-import Eth.Token exposing (CToken, TokenState)
+import Eth.Token exposing (CToken)
 
 
 getUnderlyingBalances : CompoundState -> ContractAddress -> Maybe CTokenBalances
@@ -83,6 +83,13 @@ getInterestRate cTokenMetadataDict (Contract cTokenAddress) =
     cTokenMetadataDict
         |> Dict.get cTokenAddress
         |> Maybe.map (\metaData -> { borrowRate = metaData.borrowRate, supplyRate = metaData.supplyRate })
+
+getMintGuardianPaused : CTokenMetadataDict -> ContractAddress -> Bool
+getMintGuardianPaused cTokenMetadataDict (Contract cTokenAddress) =
+    cTokenMetadataDict
+        |> Dict.get cTokenAddress
+        |> Maybe.map .mintGuardianPaused
+        |> Maybe.withDefault False
 
 
 type alias UnderlyingBalanceTotals =

--- a/src/elm/CompoundApi/Presidio/CTokens/Decoders.elm
+++ b/src/elm/CompoundApi/Presidio/CTokens/Decoders.elm
@@ -87,6 +87,7 @@ cTokenDecoder =
         |> andThen renameDaiNameToSaiLegacyDecoder
         |> andThen renameUsdtToTetherDecoder
         |> andThen renameAugurToDeprecatedDecoder
+        |> andThen renameFeiToDeprecatedDecoder
         |> andThen renameOldWbtcToLegacyDecoder
 
 
@@ -156,6 +157,20 @@ renameAugurToDeprecatedDecoder apiToken =
         ( underlyingName, underlyingSymbol ) =
             if apiToken.underlying_symbol == "REP" && apiToken.underlying_name == "Augur" then
                 ( "Augur v1 (Deprecated)", apiToken.underlying_symbol )
+
+            else
+                ( apiToken.underlying_name, apiToken.underlying_symbol )
+    in
+    succeed { apiToken | underlying_name = underlyingName, underlying_symbol = underlyingSymbol }
+
+renameFeiToDeprecatedDecoder : CToken -> Json.Decode.Decoder CToken
+renameFeiToDeprecatedDecoder apiToken =
+    let
+        -- Doing a rename based on the symbol and name combo of USDT in the Underlying since
+        -- we want to say Tether here.
+        ( underlyingName, underlyingSymbol ) =
+            if apiToken.underlying_symbol == "FEI" && apiToken.underlying_name == "Fei USD" then
+                ( "Fei USD (Deprecated)", apiToken.underlying_symbol )
 
             else
                 ( apiToken.underlying_name, apiToken.underlying_symbol )

--- a/src/elm/Utils/CTokenHelper.elm
+++ b/src/elm/Utils/CTokenHelper.elm
@@ -1,7 +1,7 @@
 module Utils.CTokenHelper exposing (getAllSupportedCTokens)
 
 import Balances
-import Decimal exposing (Decimal)
+import Decimal
 import Dict
 import Eth.Compound exposing (CompoundState)
 import Eth.Token exposing (CToken, TokenState)
@@ -13,7 +13,7 @@ getAllSupportedCTokens compoundState tokenState =
         |> Dict.values
         |> List.filterMap
             (\cToken ->
-                if cToken.symbol == "cSAI" || cToken.symbol == "cREP" || cToken.symbol == "cWBTC" then
+                if cToken.symbol == "cSAI" || cToken.symbol == "cREP" || cToken.symbol == "cWBTC" || cToken.symbol == "cFEI" || Balances.getMintGuardianPaused compoundState.cTokensMetadata cToken.contractAddress then
                     let
                         underlyingBalances =
                             Balances.getUnderlyingBalances compoundState cToken.contractAddress


### PR DESCRIPTION
This patch updates `Fei USD` as `Fei USD (Deprecated)`.  `FEI` is added to the list of markets that don't show up in the app unless the user has a balance. In addition, this patch does not display cTokens that have `mintGuardianPaused == True`, unless the user has a balance.