### PR TITLE
Update the V2 dapp's browser tab title from 'Compound | Dashboard' -> 'Compound | V2'

### DIFF
--- a/src/elm/DappInterface/Page.elm
+++ b/src/elm/DappInterface/Page.elm
@@ -32,7 +32,7 @@ getPageTitle userLanguage page =
             buildTitle userLanguage Nothing
 
         Home ->
-            buildTitle userLanguage (Just (Translations.site_title_dashboard userLanguage))
+            buildTitle userLanguage (Just (Translations.site_title_v2 userLanguage))
 
         Liquidate ->
             buildTitle userLanguage (Just (Translations.site_title_liquidate userLanguage))

--- a/src/strings/strings.en.json
+++ b/src/strings/strings.en.json
@@ -163,6 +163,7 @@
   "site_title_liquidate": "Liquidate",
   "site_title_terms": "Terms",
   "site_title_dashboard": "Dashboard",
+  "site_title_v2": "V2",
   "site_title_propose": "Create Proposal",
   "site_title_vote": "Vote",
 

--- a/src/strings/strings.es.json
+++ b/src/strings/strings.es.json
@@ -163,6 +163,7 @@
     "site_title_liquidate": "Liquidar",
     "site_title_terms": "Condiciones",
     "site_title_dashboard": "Tablero",
+    "site_title_v2": "V2",
     "site_title_propose": "Crear propuesta",
     "site_title_vote": "Votar",
 

--- a/src/strings/strings.fr.json
+++ b/src/strings/strings.fr.json
@@ -163,6 +163,7 @@
     "site_title_liquidate": "Liquider",
     "site_title_terms": "termes",
     "site_title_dashboard": "Tableau de bord",
+    "site_title_v2": "V2",
     "site_title_propose": "Créer une proposition",
     "site_title_vote": "Voter",
 

--- a/src/strings/strings.ko.json
+++ b/src/strings/strings.ko.json
@@ -163,6 +163,7 @@
     "site_title_liquidate": "청산",
     "site_title_terms": "약관",
     "site_title_dashboard": "대시보드",
+    "site_title_v2": "V2",
     "site_title_propose": "제안서 작성",
     "site_title_vote": "투표",
 

--- a/src/strings/strings.zh.json
+++ b/src/strings/strings.zh.json
@@ -163,6 +163,7 @@
     "site_title_liquidate": "清算",
     "site_title_terms": "条款",
     "site_title_dashboard": "总览",
+    "site_title_v2": "V2",
     "site_title_propose": "创建提案",
     "site_title_vote": "投票",
 


### PR DESCRIPTION
Now that we have v3 which is the official `Compound | Dashboard`, put in this quick change to rename the deprecated, V2 dashboard