### PR TITLE
Add a top-level nav link to the new V2 Markets page

### DIFF
--- a/src/elm/DappInterface/CommonViews.elm
+++ b/src/elm/DappInterface/CommonViews.elm
@@ -174,8 +174,10 @@ pageHeader userLanguage page connectedWallet account _ governanceState _ =
 
                         _ ->
                             emptyClasses
+                v2MarketsExternalLink = "https://app.compound.finance/markets?market=1_Compound+V2_0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B"
             in
             [ a (class homeClass :: href PageNavigation (getHrefUrl Home)) [ text (Translations.dashboard userLanguage) ]
+            , a (href External (v2MarketsExternalLink)) [ text (Translations.markets userLanguage) ]
             , a (class voteClass :: href PageNavigation (getHrefUrl Vote)) [ text (Translations.vote userLanguage) ]
             ]
     in


### PR DESCRIPTION
The new dapp has been out for a while now, and we've also supported a V2 markets page on it. You can find it here:
https://app.compound.finance/markets?market=1_Compound+V2_0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B

It's not easily discoverable for V2 users though, so this change adds a new external nav link to the new V2 markets page.

<img width="349" alt="image" src="https://user-images.githubusercontent.com/15851351/216216070-d8f8b5ca-5596-440b-847f-557f31801d84.png">

links to here:
<img width="895" alt="image" src="https://user-images.githubusercontent.com/15851351/216216295-19c2a727-ad46-4ea6-8f4b-b3036ed2f6fd.png">
