### PR TITLE
update GA to reference correct release artifact workflow path

### DIFF
--- a/.github/workflows/release-hash.yml
+++ b/.github/workflows/release-hash.yml
@@ -30,7 +30,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
-          workflow: build.yaml
+          workflow: build-workflow.yaml
           workflow_conclusion: success
           branch: main
           name: .release


### PR DESCRIPTION
Super quick fix to resolve the issue where release is failing since the release artifact path is not correct https://github.com/compound-finance/palisade/actions/runs/4088457904/jobs/7050148063