### PR TITLE
migrate get gas price endpoint to v3 api

### DIFF
--- a/config/env/development.json
+++ b/config/env/development.json
@@ -5,7 +5,8 @@
     "kovan": "https://api.stage.compound.finance/api/",
     "rinkeby": "https://api.stage.compound.finance/api/",
     "ropsten": "https://api.stage.compound.finance/api/",
-    "mainnet": "https://api.compound.finance/api/"
+    "mainnet": "https://api.compound.finance/api/",
+    "v3_api": "https://v3-api-stage.compound.finance/"
   },
   "DATA_PROVIDERS": {
     "development": "http://localhost:8545",

--- a/config/env/production.json
+++ b/config/env/production.json
@@ -4,7 +4,8 @@
     "kovan": "https://api.compound.finance/api/",
     "rinkeby": "https://api.compound.finance/api/",
     "ropsten": "https://api.compound.finance/api/",
-    "mainnet": "https://api.compound.finance/api/"
+    "mainnet": "https://api.compound.finance/api/",
+    "v3_api": "https://v3-api.compound.finance/"
   },
   "DATA_PROVIDERS": {
     "development": "http://localhost:8545",

--- a/src/elm/CompoundApi/GasService/Urls.elm
+++ b/src/elm/CompoundApi/GasService/Urls.elm
@@ -1,10 +1,11 @@
 module CompoundApi.GasService.Urls exposing (getGasPriceUrl)
-
-import CompoundApi.Common.Url
-import CompoundComponents.Eth.Network exposing (Network)
+import CompoundComponents.Eth.Network exposing (Network, networkName)
+import Url.Builder as UrlBuilder
+import String exposing (toLower)
 import Dict exposing (Dict)
 
 
 getGasPriceUrl : Dict String String -> Network -> Maybe String
 getGasPriceUrl apiBaseUrlMap network =
-    CompoundApi.Common.Url.buildApiUrl apiBaseUrlMap network "gas_prices/get_gas_price" []
+    Dict.get "v3_api" apiBaseUrlMap
+        |> Maybe.map (\apiBaseUrl -> apiBaseUrl ++ UrlBuilder.relative [ "legacy", toLower (networkName network), "gas-price" ] [])


### PR DESCRIPTION
We are deprecating the V2 Compound API, api.compound.finance and replacing it with a new V3 api, v3-api.compound.finance.

This PR migrates one of the API endpoints used on the legacy dapp, `/get-gas-price`
