### PR TITLE
migrate off deprecated V2 accounts/ endpoint

### DIFF
--- a/src/elm/CompoundApi/Presidio/Accounts/Urls.elm
+++ b/src/elm/CompoundApi/Presidio/Accounts/Urls.elm
@@ -9,44 +9,4 @@ import Url.Builder as UrlBuilder
 
 
 accountsRequestUrl : Dict String String -> Network -> AccountRequest -> Maybe String
-accountsRequestUrl apiBaseUrlMap network accountsRequest =
-    let
-        requiredQueryParams =
-            [ UrlBuilder.string "page_size" (String.fromInt accountsRequest.page_size)
-            , UrlBuilder.string "page_number" (String.fromInt accountsRequest.page_number)
-            , UrlBuilder.string "block_number" (String.fromInt accountsRequest.block_number)
-            ]
-
-        intermediateQueryParams =
-            requiredQueryParams
-                ++ (case accountsRequest.addresses of
-                        [] ->
-                            []
-
-                        addressList ->
-                            let
-                                addressesQueryArg =
-                                    addressList
-                                        |> String.join ","
-                            in
-                            [ UrlBuilder.string "addresses" addressesQueryArg ]
-                   )
-
-        finalQueryParams =
-            intermediateQueryParams
-                ++ (case accountsRequest.min_borrow_value_in_eth of
-                        Just minBorrowValueEth ->
-                            [ UrlBuilder.string "min_borrow_value_in_eth[value]" (Decimal.toString minBorrowValueEth) ]
-
-                        Nothing ->
-                            []
-                   )
-                ++ (case accountsRequest.max_health of
-                        Just maxHealth ->
-                            [ UrlBuilder.string "max_health[value]" (Decimal.toString maxHealth) ]
-
-                        Nothing ->
-                            []
-                   )
-    in
-    CompoundApi.Common.Url.buildApiUrl apiBaseUrlMap network "v2/account" finalQueryParams
+accountsRequestUrl apiBaseUrlMap network accountsRequest = Nothing

--- a/src/elm/DappInterface/BorrowingPane.elm
+++ b/src/elm/DappInterface/BorrowingPane.elm
@@ -322,19 +322,6 @@ borrowedAssetRow isAllMarketsRow config ( maybeCustomerAddress, maybeEtherBalanc
             DisplayCurrency.formatMarketSize preferences.displayCurrency maybeEtherUsdPrice
                 >> Maybe.withDefault "―"
 
-        borrowInterestAccruedSubtitle =
-            case maybeBorrowInterestAccrued of
-                Just borrowInterestAccrued ->
-                    borrowInterestAccrued
-                        |> tokenFormatter
-
-                Nothing ->
-                    if Decimal.eq borrowBalanceUsd Decimal.zero then
-                        "–"
-
-                    else
-                        Translations.tbd userLanguage
-
         ( balanceColumnContents, percentOfBorrowColumnContents ) =
             if isAllMarketsRow then
                 ( div [ class "balance" ]
@@ -374,17 +361,8 @@ borrowedAssetRow isAllMarketsRow config ( maybeCustomerAddress, maybeEtherBalanc
             ]
         , div [ class "col-xs-0 col-sm-3 text-right mobile-hide" ]
             [ div [ class "balance" ]
-                (div []
-                    [ text (formatPercentageWithDots (Just borrowInterestRate)) ]
-                    :: (if not isAllMarketsRow then
-                            [ span [ class "subtitle" ]
-                                [ text borrowInterestAccruedSubtitle ]
-                            ]
-
-                        else
-                            [ text "" ]
-                       )
-                )
+                [ div [] [ text (formatPercentageWithDots (Just borrowInterestRate)) ]
+                ]
             ]
         , div [ class "col-xs-4 col-sm-3 text-right" ]
             [ balanceColumnContents

--- a/src/elm/DappInterface/CollateralPane.elm
+++ b/src/elm/DappInterface/CollateralPane.elm
@@ -88,7 +88,7 @@ collateralListOrAllMarketsPanel maybeConfig maybeEtherUsdPrice ({ account, userL
         columnLabels =
             div [ class "panel__labels" ]
                 [ div [ class "col-xs-4 col-sm-4" ] [ label [] [ text (Translations.asset userLanguage) ] ]
-                , div [ class "col-xs-0 col-sm-3 text-right mobile-hide" ] [ label [] [ text (Translations.apy_slash_earned userLanguage) ] ]
+                , div [ class "col-xs-0 col-sm-3 text-right mobile-hide" ] [ label [] [ text (Translations.apy userLanguage) ] ]
                 , div [ class "col-xs-4 col-sm-3 text-right" ] [ label [] [ text (Translations.balance userLanguage) ] ]
                 , div [ class "col-xs-4 col-sm-2 text-right" ] [ label [] [ text (Translations.borrow_against userLanguage) ] ]
                 ]
@@ -281,19 +281,6 @@ collateralAssetRow isAllMarketsRow config ( maybeCustomerAddress, maybeEtherBala
         formatCurrencyFunc =
             DisplayCurrency.formatDisplayCurrencyInNumberSpec preferences.displayCurrency maybeEtherUsdPrice
 
-        supplyInterestEarnedSubtitle =
-            case maybeSupplyInterestEarned of
-                Just supplyInterestEarned ->
-                    supplyInterestEarned
-                        |> tokenFormatter
-
-                Nothing ->
-                    if Decimal.eq supplyBalanceUsd Decimal.zero then
-                        "–"
-
-                    else
-                        Translations.tbd userLanguage
-
         ( onClickMsg, switchClass, inputExtraMarkup ) =
             case maybeCustomerAddress of
                 Just _ ->
@@ -383,17 +370,8 @@ collateralAssetRow isAllMarketsRow config ( maybeCustomerAddress, maybeEtherBala
             ]
         , div [ class "col-xs-0 col-sm-3 text-right mobile-hide" ]
             [ div [ class "balance" ]
-                (div []
-                    [ text (formatPercentageWithDots (Just supplyInterestRate)) ]
-                    :: (if not isAllMarketsRow then
-                            [ span [ class "subtitle" ]
-                                [ text supplyInterestEarnedSubtitle ]
-                            ]
-
-                        else
-                            [ text "" ]
-                       )
-                )
+                [ div [] [ text (formatPercentageWithDots (Just supplyInterestRate)) ]
+                ]
             ]
         , div [ class "col-xs-4 col-sm-3 text-right" ]
             [ balanceColumnContents

--- a/src/elm/Liquidate.elm
+++ b/src/elm/Liquidate.elm
@@ -12,9 +12,7 @@ port module Liquidate exposing
     , view
     )
 
-import CompoundApi.Presidio.Accounts.Decoders exposing (accountsResponseDecoder)
 import CompoundApi.Presidio.Accounts.Models exposing (AccountResponse)
-import CompoundApi.Presidio.Accounts.Urls
 import CompoundComponents.Console as Console
 import CompoundComponents.DisplayCurrency as DisplayCurrency exposing (DisplayCurrency)
 import CompoundComponents.Eth.Decoders exposing (decimal, decodeAssetAddress, decodeCustomerAddress)
@@ -339,31 +337,7 @@ view userLanguage currentTimeZone maybeConfig maybeNetwork account compoundState
 
 
 loadPresidioBorrows : Dict String String -> Network -> Cmd Msg
-loadPresidioBorrows apiBaseUrlMap network =
-    let
-        maybeAccountsUrl =
-            { addresses = []
-            , min_borrow_value_in_eth = Just minBorrowEthAmount
-            , max_health = Just maxHealthAmount
-            , block_number = 0
-            , page_size = 100
-            , page_number = 1
-            }
-                |> CompoundApi.Presidio.Accounts.Urls.accountsRequestUrl apiBaseUrlMap network
-
-        accountsRequestCmd =
-            case maybeAccountsUrl of
-                Just accountsUrl ->
-                    let
-                        accountsRequestHttpGet =
-                            Http.get accountsUrl accountsResponseDecoder
-                    in
-                    Http.send (ForSelf << PresidioAccountsResponse) accountsRequestHttpGet
-
-                _ ->
-                    Cmd.none
-    in
-    accountsRequestCmd
+loadPresidioBorrows apiBaseUrlMap network = Cmd.none
 
 
 loadAtRiskAccounts : Config -> Account -> Maybe Int -> Dict String String -> Network -> Cmd Msg

--- a/src/elm/Liquidate.elm
+++ b/src/elm/Liquidate.elm
@@ -334,15 +334,9 @@ view userLanguage currentTimeZone maybeConfig maybeNetwork account compoundState
 
 
 -- Get accounts
-
-
-loadPresidioBorrows : Dict String String -> Network -> Cmd Msg
-loadPresidioBorrows apiBaseUrlMap network = Cmd.none
-
-
 loadAtRiskAccounts : Config -> Account -> Maybe Int -> Dict String String -> Network -> Cmd Msg
 loadAtRiskAccounts config account maybeBlockNumber apiBaseUrlMap network =
-    loadPresidioBorrows apiBaseUrlMap network
+    Cmd.none
 
 
 updateBorrowerDetailWithPresidioAccount : Config -> TokenState -> OracleState -> CompoundApi.Presidio.Accounts.Models.Account -> Dict String BorrowerDetail -> Dict String BorrowerDetail


### PR DESCRIPTION
We're migrating off the deprecated V2 API, and one of the values that it previously tracked was lifetime interest.
With this new migration, we will _no longer_ show the lifetime interest, mirroring how we similarly don't do it for the Compound III dapp

<img width="378" alt="image" src="https://user-images.githubusercontent.com/15851351/223291540-924ab7e8-de6b-4fba-8333-f5836abb61ce.png">
