### PR TITLE
remove V2 API url from API config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,7 @@ The following is an example configuration file:
 ```json
 {
   "API_BASE_URL_MAP": {
-    "goerli": "https://api.compound.finance/api/",
-    "kovan": "https://api.compound.finance/api/",
-    "rinkeby": "https://api.compound.finance/api/",
-    "ropsten": "https://api.compound.finance/api/",
-    "mainnet": "https://api.compound.finance/api/"
+    "v3_api": "https://v3-api.compound.finance/"
   },
   "DATA_PROVIDERS": {
     "development": "http://localhost:8545",

--- a/config/env/development.json
+++ b/config/env/development.json
@@ -1,11 +1,5 @@
 {
   "API_BASE_URL_MAP": {
-    "development": "http://localhost:4000/",
-    "goerli": "https://api.stage.compound.finance/api/",
-    "kovan": "https://api.stage.compound.finance/api/",
-    "rinkeby": "https://api.stage.compound.finance/api/",
-    "ropsten": "https://api.stage.compound.finance/api/",
-    "mainnet": "https://api.compound.finance/api/",
     "v3_api": "https://v3-api-stage.compound.finance/"
   },
   "DATA_PROVIDERS": {

--- a/config/env/production.json
+++ b/config/env/production.json
@@ -1,10 +1,5 @@
 {
   "API_BASE_URL_MAP": {
-    "goerli": "https://api.compound.finance/api/",
-    "kovan": "https://api.compound.finance/api/",
-    "rinkeby": "https://api.compound.finance/api/",
-    "ropsten": "https://api.compound.finance/api/",
-    "mainnet": "https://api.compound.finance/api/",
     "v3_api": "https://v3-api.compound.finance/"
   },
   "DATA_PROVIDERS": {


### PR DESCRIPTION
We are sunsetting the V2 API soon. This PR removes the V2 API URL from palisade's config, so that no accidental calls can be made to it from the dapp.