### PR TITLE
respect locale query param lang in v2 dapp

### DIFF
--- a/src/js/ports.js
+++ b/src/js/ports.js
@@ -11,6 +11,7 @@ import storage from './storage';
 import { requestForeground } from './helpers';
 import {
   debug,
+  langFromURL,
   shouldAutoConnect,
   supportFromEntries,
 } from '../../node_modules/compound-components/src/js/sharedEth/utils';
@@ -539,6 +540,8 @@ function subscribeToStoreTransaction(app, eth) {
 }
 
 function subscribeToPreferences(app, eth) {
+  const url = new URL(window.location);
+  const lang = langFromURL(url, window.navigator.language);
   // port storePreferencesPort : { displayCurrency : String, userLanguage : String, supplyPaneOpen : Bool, borrowPaneOpen : Bool } -> Cmd msg
   app.ports.storePreferencesPort.subscribe((preferences) => {
     preferencesStorage.set(preferences);
@@ -547,8 +550,7 @@ function subscribeToPreferences(app, eth) {
   // port askStoredPreferencesPort : {} -> Cmd msg
   app.ports.askStoredPreferencesPort.subscribe(() => {
     const preferences = preferencesStorage.get();
-
-    app.ports.giveStoredPreferencesPort.send(preferences);
+    app.ports.giveStoredPreferencesPort.send({userLanguage: lang, ...preferences});
   });
 
   // port askClearPreferencesPort : {} -> Cmd msg


### PR DESCRIPTION
The `locale` query param sets the user's language on the Elm model on init:
https://github.com/compound-finance/palisade/blob/cc4b0bc0ff08d3aab76477a642b3461dd21a5241/src/js/dapp.js#L69
but then it quickly gets overridden when listening to updates here:
https://github.com/compound-finance/palisade/blob/cc4b0bc0ff08d3aab76477a642b3461dd21a5241/src/elm/Main.elm#L1058
and what's interesting is that the sent `preferences` message could be empty if local storage is not set, so it'll default to English:
https://github.com/compound-finance/palisade/blob/cc4b0bc0ff08d3aab76477a642b3461dd21a5241/src/js/ports.js#L551

This fix basically sets the user language to be based on the `locale` query param, if there are no user preferences defined in local storage already.