### PR TITLE
update V2 Dapp URLs to use shortlinks

### DIFF
--- a/src/elm/DappInterface/CommonViews.elm
+++ b/src/elm/DappInterface/CommonViews.elm
@@ -174,7 +174,7 @@ pageHeader userLanguage page connectedWallet account _ governanceState _ =
 
                         _ ->
                             emptyClasses
-                v2MarketsExternalLink = "https://app.compound.finance/markets?market=1_Compound+V2_0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B"
+                v2MarketsExternalLink = "https://app.compound.finance/markets?market=v2"
             in
             [ a (class homeClass :: href PageNavigation (getHrefUrl Home)) [ text (Translations.dashboard userLanguage) ]
             , a (href External (v2MarketsExternalLink)) [ text (Translations.markets userLanguage) ]
@@ -215,7 +215,7 @@ pageFooter userLanguage maybeBlockNumber preferences model =
                 [ div [ class "col-xs-12 col-sm-2" ]
                     [ a ([ class "brand" ] |> List.append (href PageNavigation "/")) [] ]
                 , div [ class "col-xs-12 col-sm-10 links" ]
-                    [ a (target "_blank" :: href External "https://app.compound.finance/markets?market=1_V2_0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B") [ text (Translations.markets userLanguage) ]
+                    [ a (target "_blank" :: href External "https://app.compound.finance/markets?market=v2") [ text (Translations.markets userLanguage) ]
                     , a (target "_blank" :: href External "https://compound.finance/governance") [ text (Translations.governance userLanguage) ]
                     , a (target "_blank" :: href External "https://compound.finance/governance/comp") [ text (Translations.comp userLanguage) ]
                     , a (href PageNavigation (getHrefUrl TermsOfService)) [ text (Translations.terms userLanguage) ]
@@ -227,7 +227,7 @@ pageFooter userLanguage maybeBlockNumber preferences model =
                     [ div [ class "mobile-hide" ]
                         [ span [ class ("dot-indicator" ++ indicatorColorClass) ] []
                         , label [ class "small" ] [ text (Translations.latest_block userLanguage (formatBlockNumber maybeBlockNumber)) ]
-                        , a (target "_blank" :: href External "https://app.compound.finance/markets?market=1_V2_0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B") [ text (Translations.markets userLanguage) ]
+                        , a (target "_blank" :: href External "https://app.compound.finance/markets?market=v2") [ text (Translations.markets userLanguage) ]
                         , a (target "_blank" :: href External "https://compound.finance/governance") [ text (Translations.governance userLanguage) ]
                         , a (target "_blank" :: href External "https://compound.finance/governance/comp") [ text (Translations.comp userLanguage) ]
                         , a (target "_blank" :: href External "https://medium.com/compound-finance/the-compound-guide-to-supplying-borrowing-crypto-assets-94821f2950a0") [ text (Translations.support userLanguage) ]

--- a/src/elm/DappInterface/PrimaryActionModal.elm
+++ b/src/elm/DappInterface/PrimaryActionModal.elm
@@ -368,21 +368,6 @@ view mainModel =
 
 
 -- aka right side of pane (bottom on mobile)
-
-
-marketDetailPageUrl : CToken -> String
-marketDetailPageUrl chosenAsset =
-    let
-        targetUnderlyingSymbol =
-            if chosenAsset.symbol == "cWBTC2" then
-                "WBTC2"
-
-            else
-                chosenAsset.underlying.symbol
-    in
-    "https://compound.finance/markets/" ++ targetUnderlyingSymbol
-
-
 inputActionPane : Translations.Lang -> Maybe Config -> Maybe Decimal -> PrimaryActionModalState -> Model -> Html Msg
 inputActionPane userLanguage maybeConfig maybeEtherUsdPrice primaryActionModalState mainModel =
     let
@@ -587,7 +572,7 @@ assetAndCompRateForm userLanguage config maybeEtherUsdPrice ({ chosenAsset, prim
                     "– %"
     in
     div [ class "form" ]
-        [ a ([ class "label-link", target "__blank" ] ++ href External (marketDetailPageUrl chosenAsset))
+        [ a ([ class "label-link", target "__blank" ] ++ href External "https://app.compound.finance/markets/?market=v2")
             [ label [ class "dark" ] [ text formLabel ]
             , div [ class "line-icon line-icon--small line-icon--external-link line-icon--external-link--black" ] []
             ]


### PR DESCRIPTION
Updating all of our URLs to point to the new dapp pages, including the new v2 markets page.

When expanding a ctoken's rate views - it should put to the new v2 markets page as well
![image](https://user-images.githubusercontent.com/15851351/226450995-b62c6f69-ebd1-42d5-ab60-5efb3c0d3888.png)
