### PR TITLE
Remove optional dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "react-dev-utils": "^10.2.1",
     "react-error-overlay": "^6.0.7",
     "regenerator-runtime": "^0.13.5",
-    "solc": "^0.8.19",
     "string-replace-loader": "^2.1.1",
     "style-loader": "^1.2.1",
     "sw-precache-webpack-plugin": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10430,7 +10430,7 @@ sockjs@^0.3.21:
     uuid "^3.4.0"
     websocket-driver "^0.7.4"
 
-solc@^0.8.17, solc@^0.8.19:
+solc@^0.8.17:
   version "0.8.19"
   resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.19.tgz#cac6541106ae3cff101c740042c7742aa56a2ed3"
   integrity sha512-yqurS3wzC4LdEvmMobODXqprV4MYJcVtinuxgrp61ac8K2zz40vXA0eSAskSHPgv8dQo7Nux39i3QBsHx4pqyA==


### PR DESCRIPTION
solc made it to a top-level dep and so was always being included, including in our prod cloud builds. This should fix that issue and make a 37MB vendor.js go back to a 2MB vendor.js.