### PR TITLE
WIP - Investigate large build size

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -11,15 +11,15 @@ jobs:
           echo Building ${GITHUB_REF}...
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '15.x'
+          node-version: '18.x'
 
       - name: Cache Node Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -32,7 +32,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache Elm Stuff
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-elm-stuff
         with:

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "The Compound Web3 Front-end",
   "main": "index.js",
   "scripts": {
-    "build": "node --unhandled-rejections=strict --max-old-space-size=8192 scripts/build.js",
-    "start": "node --unhandled-rejections=strict scripts/start.js dapp",
+    "build": "node --unhandled-rejections=strict --max-old-space-size=8192 --openssl-legacy-provider scripts/build.js",
+    "start": "node --unhandled-rejections=strict --openssl-legacy-provider scripts/start.js dapp",
     "package": "elm-package",
     "make": "elm-make",
     "repl": "elm-repl",
@@ -65,7 +65,6 @@
     "react-dev-utils": "^10.2.1",
     "react-error-overlay": "^6.0.7",
     "regenerator-runtime": "^0.13.5",
-    "solc": "^0.8.19",
     "string-replace-loader": "^2.1.1",
     "style-loader": "^1.2.1",
     "sw-precache-webpack-plugin": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10860,10 +10860,10 @@ sockjs@^0.3.21:
     uuid "^3.4.0"
     websocket-driver "^0.7.4"
 
-solc@^0.8.17, solc@^0.8.19:
-  version "0.8.19"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.19.tgz#cac6541106ae3cff101c740042c7742aa56a2ed3"
-  integrity sha512-yqurS3wzC4LdEvmMobODXqprV4MYJcVtinuxgrp61ac8K2zz40vXA0eSAskSHPgv8dQo7Nux39i3QBsHx4pqyA==
+solc@^0.8.17:
+  version "0.8.21"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.21.tgz#c3cd505c360ea2fa0eaa5ab574ef96bffb1a2766"
+  integrity sha512-N55ogy2dkTRwiONbj4e6wMZqUNaLZkiRcjGyeafjLYzo/tf/IvhHY5P5wpe+H3Fubh9idu071i8eOGO31s1ylg==
   dependencies:
     command-exists "^1.2.8"
     commander "^8.1.0"


### PR DESCRIPTION
Remove solc from dependencies and update node version to 18. This looks to reduce the vendors chunk by not having solc installed in node_modules and the build generated locally looks way smaller.

<img width="703" alt="Screen Shot 2023-08-09 at 2 25 11 PM" src="https://github.com/compound-finance/palisade/assets/10445874/214cea8a-4133-4cfe-9c15-e1ab5c42c654">

However, the git action job won't generate a build because of the warning of `solc` not being able to be resolved in sleuth even though we don't use that method as it's only for supporting non-precompiled contracts.