### PR TITLE
Feat: Pin the release artifacts CID to Crust Network to make Compound front-end deployed in more distributed and reliable IPFS network

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -86,6 +86,19 @@ jobs:
           name: .release
           path: .release
 
+      - name: Get CID
+        id: getcid
+        run: echo "cid=$(cat .release)" >> $GITHUB_OUTPUT
+        continue-on-error: true
+
+      - name: Pin CID to Crust Network
+        id: pintocrust
+        uses: crustio/ipfs-crust-action@v2.0.7
+        continue-on-error: true
+        with:
+          cid: ${{ steps.getcid.outputs.cid }}
+          seeds: ${{ secrets.CRUST_SEEDS }}
+
       - name: Add Deploy Comment
         uses: machine-learning-apps/pr-comment@master
         env:


### PR DESCRIPTION
## Changes
Update the build-workflow.yml to add additional steps to pin the release artifacts CID to Crust Network.

"continue-on-error: true" flag is set to make sure this new workflow step would not break the build, so no any bad side-impact for this change.

## Admin Notes
The repo admin or owner needs to set the secrets 'CRUST_SEEDS' in the repo's 'Setting' in order to make this change effective.

Crust Network will provide free CRUST_SEEDS for Compound to use, so do not have any additional charge for Compound.

## Background and Objective
IPFS is a p2p network, more hosting nodes will ensure more distributed, secure, faster, and stable access experience.

[Crust Network](https://www.crust.network/) is the world's leading web3 decentralized storage provider, which runs over 1000+ distributed nodes and provides over 500+ PB storage capacity all over the world.

Pin the Compound website front-end to Crust IPFS Network will provide faster and more stable access experience for end users.

