### PR TITLE
fix v2-app Markets link

### DIFF
--- a/src/elm/DappInterface/CommonViews.elm
+++ b/src/elm/DappInterface/CommonViews.elm
@@ -170,12 +170,16 @@ pageHeader userLanguage page connectedWallet account _ governanceState _ =
 
                         _ ->
                             emptyClasses
-                v2MarketsExternalLink = "https://app.compound.finance/markets?market=v2"
-                v3VoteExternalLink = "https://app.compound.finance/vote"
+
+                v2MarketsExternalLink =
+                    "https://app.compound.finance/markets/v2"
+
+                v3VoteExternalLink =
+                    "https://app.compound.finance/vote"
             in
             [ a (class homeClass :: href PageNavigation (getHrefUrl Home)) [ text (Translations.dashboard userLanguage) ]
-            , a (href External (v2MarketsExternalLink)) [ text (Translations.markets userLanguage) ]
-            , a (href External (v3VoteExternalLink)) [ text (Translations.vote userLanguage) ]
+            , a (href External v2MarketsExternalLink) [ text (Translations.markets userLanguage) ]
+            , a (href External v3VoteExternalLink) [ text (Translations.vote userLanguage) ]
             ]
     in
     header [ class "dapp" ]
@@ -212,7 +216,7 @@ pageFooter userLanguage maybeBlockNumber preferences model =
                 [ div [ class "col-xs-12 col-sm-2" ]
                     [ a ([ class "brand" ] |> List.append (href PageNavigation "/")) [] ]
                 , div [ class "col-xs-12 col-sm-10 links" ]
-                    [ a (target "_blank" :: href External "https://app.compound.finance/markets?market=v2") [ text (Translations.markets userLanguage) ]
+                    [ a (target "_blank" :: href External "https://app.compound.finance/markets/v2") [ text (Translations.markets userLanguage) ]
                     , a (target "_blank" :: href External "https://compound.finance/governance") [ text (Translations.governance userLanguage) ]
                     , a (target "_blank" :: href External "https://compound.finance/governance/comp") [ text (Translations.comp userLanguage) ]
                     , a (href PageNavigation (getHrefUrl TermsOfService)) [ text (Translations.terms userLanguage) ]
@@ -224,7 +228,7 @@ pageFooter userLanguage maybeBlockNumber preferences model =
                     [ div [ class "mobile-hide" ]
                         [ span [ class ("dot-indicator" ++ indicatorColorClass) ] []
                         , label [ class "small" ] [ text (Translations.latest_block userLanguage (formatBlockNumber maybeBlockNumber)) ]
-                        , a (target "_blank" :: href External "https://app.compound.finance/markets?market=v2") [ text (Translations.markets userLanguage) ]
+                        , a (target "_blank" :: href External "https://app.compound.finance/markets/v2") [ text (Translations.markets userLanguage) ]
                         , a (target "_blank" :: href External "https://compound.finance/governance") [ text (Translations.governance userLanguage) ]
                         , a (target "_blank" :: href External "https://compound.finance/governance/comp") [ text (Translations.comp userLanguage) ]
                         , a (target "_blank" :: href External "https://medium.com/compound-finance/the-compound-guide-to-supplying-borrowing-crypto-assets-94821f2950a0") [ text (Translations.support userLanguage) ]

--- a/src/elm/DappInterface/PrimaryActionModal.elm
+++ b/src/elm/DappInterface/PrimaryActionModal.elm
@@ -368,6 +368,8 @@ view mainModel =
 
 
 -- aka right side of pane (bottom on mobile)
+
+
 inputActionPane : Translations.Lang -> Maybe Config -> Maybe Decimal -> PrimaryActionModalState -> Model -> Html Msg
 inputActionPane userLanguage maybeConfig maybeEtherUsdPrice primaryActionModalState mainModel =
     let
@@ -543,6 +545,7 @@ assetAndCompRateForm userLanguage config maybeEtherUsdPrice ({ chosenAsset, prim
                             compSpeedPerDayForAction =
                                 if primaryActionType == MintAction || primaryActionType == RedeemAction then
                                     cTokenMetadata.compSupplySpeedPerDay
+
                                 else
                                     cTokenMetadata.compBorrowSpeedPerDay
                         in
@@ -572,7 +575,7 @@ assetAndCompRateForm userLanguage config maybeEtherUsdPrice ({ chosenAsset, prim
                     "– %"
     in
     div [ class "form" ]
-        [ a ([ class "label-link", target "__blank" ] ++ href External "https://app.compound.finance/markets/?market=v2")
+        [ a ([ class "label-link", target "__blank" ] ++ href External "https://app.compound.finance/markets/v2")
             [ label [ class "dark" ] [ text formLabel ]
             , div [ class "line-icon line-icon--small line-icon--external-link line-icon--external-link--black" ] []
             ]


### PR DESCRIPTION
v2 markets page doesn't load on webb3 when going from the links on Palisade.

after investigation i realized https://app.compound.finance/markets/v2 works, https://app.compound.finance/markets?market=v2 doesn't. so the fix is to correct the URLs since we recently made changes to market deep-linking.

Issue: https://linear.app/compound-finance/issue/ENG-39/bug-using-v2-apps-market-link-never-loads-the-webb3-market-content