### PR TITLE
Remove BlockNative as notify API is being deprecated.

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -64,7 +64,6 @@ jobs:
         run: yarn build
         env:
           DATA_PROVIDERS: ${{ secrets.DATA_PROVIDERS }}
-          BLOCKNATIVE_API_KEY: ${{ secrets.BLOCKNATIVE_API_KEY }}
           WALLET_CONNECT_PROJECT_ID: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
 
       - name: Archive App

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ The following is an example configuration file:
     "development": 999
   },
   "DEFAULT_NETWORK": "mainnet",
-  "BLOCKNATIVE_API_KEY": "YOUR_BLOCKNATIVE_KEY",
   "WALLET_CONNECT_PROJECT_ID": "YOUR_WALLET_CONNECT_PROJECT_ID"
 }
 ```
@@ -53,7 +52,6 @@ Each of the top level keys have the following functions:
 - `API_BASE_URL_MAP` - Object mapping of Eth network name as key and value being the desired Compound Api host. This can be left as is.
 - `DATA_PROVIDERS` - Object mapping of Eth network name as key and value being the url of a corresponding JSON RPC host. This example shows Infura as a sample JSON RPC provider and you can find more information [here](https://infura.io/docs/ethereum). Note: this can be specified by setting in the env var `DATA_PROVIDERS` as JSON (e.g. `export DATA_PROVIDERS='{"rinkeby": "https://infura.io/..."}'`).
 - `NETWORK_MAP` - Object mapping of Eth network name as key and value being the corresponding NetworkId value. This can be left as is.
-- `BLOCKNATIVE_API_KEY` - Blocknative API Key required to track transaction notifications. You can find more information [here](https://docs.blocknative.com/notify). Note: this can be specified by setting the env var `BLOCKNATIVE_API_KEY`. This key is not strictly required (but provides a better user experience).
 - `WALLET_CONNECT_PROJECT_ID` - Wallect Connect Project Id required to use Wallet Connect as a wallet type in the app. You can find more information [here](https://docs.walletconnect.com/2.0/). Note: this can be specified by setting the env var `WALLET_CONNECT_PROJECT_ID`. This id is not required unless you want to enable wallet connect usage.
 
 ## Getting Started

--- a/config/env.js
+++ b/config/env.js
@@ -88,10 +88,6 @@ const envPath = path.join(appDirectory, '/config/env');
 const envJson = fs.readFileSync(path.join(envPath, `${CONFIG_ENV}.json`));
 const envConfig = JSON.parse(envJson);
 
-if (process.env['BLOCKNATIVE_API_KEY']) {
-  envConfig.BLOCKNATIVE_API_KEY = process.env['BLOCKNATIVE_API_KEY'];
-}
-
 if (process.env['WALLET_CONNECT_PROJECT_ID']) {
   envConfig.WALLET_CONNECT_PROJECT_ID = process.env['WALLET_CONNECT_PROJECT_ID'];
 }

--- a/config/env/development.json
+++ b/config/env/development.json
@@ -18,6 +18,5 @@
     "kovan": 42,
     "development": 999
   },
-  "DEFAULT_NETWORK": "mainnet",
-  "BLOCKNATIVE_API_KEY": null
+  "DEFAULT_NETWORK": "mainnet"
 }

--- a/config/env/production.json
+++ b/config/env/production.json
@@ -17,6 +17,5 @@
     "goerli": 5,
     "kovan": 42
   },
-  "DEFAULT_NETWORK": "mainnet",
-  "BLOCKNATIVE_API_KEY": null
+  "DEFAULT_NETWORK": "mainnet"
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "assets-webpack-plugin": "^3.5.1",
     "autoprefixer": "^9.7.6",
     "babel-loader": "^8.0.0",
-    "bnc-sdk": "^3.3.3",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",
     "chalk": "^4.0.0",
     "clean-webpack-plugin": "^3.0.0",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -14,10 +14,15 @@ async function release(cid, url, signature) {
     body: cid,
     method: 'POST',
     headers: {
-      'x-signature': signature
-    }
+      'x-signature': signature,
+    },
   });
-  const json = await res.json();
+
+  try {
+    const json = await res.json();
+  } catch (error) {
+    console.error(`Response was not valid JSON: ${error}`);
+  }
 
   if (json.cid) {
     console.log(`Successfully released: ${json.cid}`);

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -21,7 +21,7 @@ async function release(cid, url, signature) {
   try {
     const json = await res.json();
   } catch (error) {
-    console.error(`Response was not valid JSON: ${error}`);
+    throw new Error(`Response was not valid JSON: ${error}`);
   }
 
   if (json.cid) {

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -41,7 +41,7 @@ import Http
 import Json.Decode
 import Json.Encode
 import Liquidate
-import Port exposing (askNetwork, askNewBlock, askSetBlockNativeNetworkPort, giveAccountBalance, giveError, giveNewBlock, setGasPrice, setTitle)
+import Port exposing (askNetwork, askNewBlock, giveAccountBalance, giveError, giveNewBlock, setGasPrice, setTitle)
 import Preferences exposing (PreferencesMsg(..), preferencesInit, preferencesSubscriptions, preferencesUpdate)
 import Repl
 import Strings.Translations as Translations
@@ -326,7 +326,6 @@ newBlockCmd apiBaseUrlMap maybeNetwork blockNumber previousBlockNumber ({ dataPr
 
                                 _ ->
                                     []
-
                     in
                     Cmd.batch <|
                         pageCmds
@@ -373,15 +372,9 @@ handleUpdatesFromEthConnectedWallet maybeConfig connectedEthWalletMsg model =
                     else
                         model.voteModel
 
-                setBlockNativeCmd =
-                    askSetBlockNativeNetworkPort
-                        { networkId = networkId newNetwork
-                        }
-
                 cmd =
                     Cmd.batch
-                        ([ setBlockNativeCmd
-                         , refreshLatestGasPrice model.apiBaseUrlMap newNetwork
+                        ([ refreshLatestGasPrice model.apiBaseUrlMap newNetwork
                          , Cmd.map WrappedTokenMsg newTokenCmd
                          , Cmd.map liquidateTranslator newLiquidateCmd
                          ]
@@ -391,6 +384,7 @@ handleUpdatesFromEthConnectedWallet maybeConfig connectedEthWalletMsg model =
                                             refreshBlockCmd =
                                                 if model.network /= Just newNetwork then
                                                     newBlockCmd model.apiBaseUrlMap (Just newNetwork) blockNumber Nothing model
+
                                                 else
                                                     Cmd.none
                                         in
@@ -1117,9 +1111,10 @@ update msg ({ page, configs, apiBaseUrlMap, account, transactionState, bnTransac
 
 
 view : Model -> Html Msg
-view ({userLanguage} as model) =
+view ({ userLanguage } as model) =
     Html.div [ id "main" ]
         (viewFull model)
+
 
 viewFull : Model -> List (Html Msg)
 viewFull ({ page, liquidateModel, transactionState, compoundState, tokenState, oracleState, configs, configAbis, network, preferences, account, blockNumber, userLanguage } as model) =

--- a/src/elm/Port.elm
+++ b/src/elm/Port.elm
@@ -1,7 +1,6 @@
 port module Port exposing
     ( askNetwork
     , askNewBlock
-    , askSetBlockNativeNetworkPort
     , encodeParameters
     , giveAccountBalance
     , giveEncodedExtrinsic
@@ -40,13 +39,6 @@ port setTitle : String -> Cmd msg
 
 
 port giveProviderType : (Int -> msg) -> Sub msg
-
-
-
--- Update BlockNative target network
-
-
-port askSetBlockNativeNetworkPort : { networkId : Int } -> Cmd msg
 
 
 port giveAccountBalancePort : (Value -> msg) -> Sub msg

--- a/src/js/dapp.js
+++ b/src/js/dapp.js
@@ -127,7 +127,6 @@ window.addEventListener('load', function () {
     configFiles,
     configAbiFiles,
     configNameToAddressMappings,
-    process.env.BLOCKNATIVE_API_KEY,
     process.env.WALLET_CONNECT_PROJECT_ID
   );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3504,15 +3504,6 @@ bnc-sdk@^2.1.5:
     crypto-es "^1.2.2"
     sturdy-websocket "^0.1.12"
 
-bnc-sdk@^3.3.3:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/bnc-sdk/-/bnc-sdk-3.5.0.tgz#b863a2d947857d87c56d53261bd43529f1a5c03e"
-  integrity sha512-4CSon8xRTjtD7YOUDJcyqZ/bKCNNwDc4sOPq6O19AlolYTsbbVvh+p5EOmYqL4Re30hI3lKQxN4sh12A6VnAPQ==
-  dependencies:
-    crypto-es "^1.2.2"
-    rxjs "^6.6.3"
-    sturdy-websocket "^0.1.12"
-
 body-parser@1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"


### PR DESCRIPTION
Tested with repaying a borrow and exiting a market.

Since our new block check interval is every 20s, the UX could wait 20s even after the Transaction is confirmed in MM, but I don't think that's too crazy of an experience.