### PR TITLE
Increase the new block check interval to 1 minute

### DIFF
--- a/src/elm/DappInterface/MainModel.elm
+++ b/src/elm/DappInterface/MainModel.elm
@@ -155,6 +155,7 @@ type alias Model =
     , governanceState : Eth.Governance.GovernanceState
     , errors : List String
     , currentTime : Maybe Time.Posix
+    , lastNewBlockTime : Maybe Time.Posix
     , currentTimeZone : Time.Zone
     , browserType : Utils.BrowserInfo.BrowserType
     , proposeModel : Propose.Model

--- a/src/elm/Eth/Transaction.elm
+++ b/src/elm/Eth/Transaction.elm
@@ -10,6 +10,7 @@ port module Eth.Transaction exposing
     , containsTransactionType
     , filteredTransactionsByCToken
     , filteredTransactionsByComptroller
+    , getAllPendingTransactions
     , getDefaultOldestPendingTrxTime
     , getPendingTransactionsForAccount
     , giveNewTrx

--- a/src/elm/Port.elm
+++ b/src/elm/Port.elm
@@ -1,6 +1,7 @@
 port module Port exposing
     ( askNetwork
     , askNewBlock
+    , askNewBlockAsync
     , encodeParameters
     , giveAccountBalance
     , giveEncodedExtrinsic
@@ -89,6 +90,14 @@ port askNewBlockPort : {} -> Cmd msg
 askNewBlock : Cmd msg
 askNewBlock =
     askNewBlockPort {}
+
+
+port askNewBlockAsyncPort : { blockNumber : Int } -> Cmd msg
+
+
+askNewBlockAsync : Int -> Cmd msg
+askNewBlockAsync currentBlock =
+    askNewBlockAsyncPort { blockNumber = currentBlock }
 
 
 port giveNewBlockPort : (Value -> msg) -> Sub msg


### PR DESCRIPTION
However, since the current timer is done entirely in the ports logic and the pending transactions are tracked in Elm, the way I chose to implement the quicker checker if the user has pending transactions was to have a secondary check in our `Tick` function that triggers a new block check only if there are pending transactions.